### PR TITLE
Get correct path for screenshots

### DIFF
--- a/src/getfile.sh
+++ b/src/getfile.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-USER=$(whoami)
-DIR="/Users/$USER/Desktop"
+DIR=$(defaults read com.apple.screencapture location)
 FILE=$(ls -t "$DIR" | head -n 1)
 
-echo "$DIR/$FILE"
+echo "$DIR$FILE"

--- a/src/getfile.sh
+++ b/src/getfile.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 DIR=$(defaults read com.apple.screencapture location)
+if [ ! -d "$DIRECTORY" ]; then
+	USER=$(whoami)
+	DIR="/Users/$USER/Desktop/"
+fi
+
 FILE=$(ls -t "$DIR" | head -n 1)
 
 echo "$DIR$FILE"

--- a/src/getfile.sh
+++ b/src/getfile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DIR=$(defaults read com.apple.screencapture location)
-if [ ! -d "$DIRECTORY" ]; then
+if [ ! -d "$DIR" ]; then
 	USER=$(whoami)
 	DIR="/Users/$USER/Desktop/"
 fi


### PR DESCRIPTION
This patch enables the `getfile.sh` script to pull the correct path from the `defaults` command, so it should address #2 and maybe even #1.