### PR TITLE
Fix getfile.sh file path when DIR is taken from defaults

### DIFF
--- a/src/getfile.sh
+++ b/src/getfile.sh
@@ -3,9 +3,9 @@
 DIR=$(defaults read com.apple.screencapture location)
 if [ ! -d "$DIR" ]; then
 	USER=$(whoami)
-	DIR="/Users/$USER/Desktop/"
+	DIR="/Users/$USER/Desktop"
 fi
 
 FILE=$(ls -t "$DIR" | head -n 1)
 
-echo "$DIR$FILE"
+echo "$DIR/$FILE"


### PR DESCRIPTION
fixed a small problem in `getfile.sh` where if the path was taken from mac's `defaults` option (in line 3), the file path wouldn't populate correctly, resulting in file not uploading.

This makes sure the path is correct when taken the screenshot location from both ways.